### PR TITLE
chore: Bump strapi to v4.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@strapi/plugin-i18n": "4.1.9",
-    "@strapi/plugin-users-permissions": "4.1.9",
-    "@strapi/provider-upload-cloudinary": "4.1.9",
-    "@strapi/strapi": "4.1.9",
+    "@strapi/plugin-i18n": "4.3.2",
+    "@strapi/plugin-users-permissions": "4.3.2",
+    "@strapi/provider-upload-cloudinary": "4.3.2",
+    "@strapi/strapi": "4.3.2",
     "pg": "8.7.3"
   },
   "author": {


### PR DESCRIPTION
## Updated

- Bump all the `@strapi` plugins to the latest version [v4.3.2](https://github.com/strapi/strapi/releases/tag/v4.3.2)
- `pg` stays at the latests version [pg@8.7.3](https://github.com/brianc/node-postgres/releases/tag/pg%408.7.3)