### PR TITLE
set connection.pool.min = 0

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -9,5 +9,6 @@ module.exports = ({ env }) => ({
       password: env('PGPASSWORD', 'password'),
       ssl: env.bool(true),
     },
+    pool: { min: 0 }
   },
 });


### PR DESCRIPTION
reason for this change is outlined by the caution blurb here: [Database pooling options](https://docs.strapi.io/dev-docs/configurations/database#database-pooling-options)

People have been having this issue in the help threads, and setting min to 0 has always resolved their issues, so it should be standard in the railway template.